### PR TITLE
Update contribution URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Curious about using AWS SAM with Ruby and no Rails? Please see this 757rb (Norfo
 
 After checking out the repo, run `./bin/setup` to install dependencies. Then, run `./bin/test` to run the tests. **NOTE: There are no tests now but adding them is on our TODO list.**
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/metaskills/lamby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/customink/lamby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 
 ## Code of Conduct


### PR DESCRIPTION
Noticed the contribution URL in the README was referencing the older repository or based on gem instantiation 