### PR TITLE
[RequestId] Consistent CloudWatch Logs w/RequestID

### DIFF
--- a/lib/lamby/rack.rb
+++ b/lib/lamby/rack.rb
@@ -5,7 +5,7 @@ module Lamby
 
     LAMBDA_EVENT = 'lambda.event'.freeze
     LAMBDA_CONTEXT = 'lambda.context'.freeze
-    HTTP_X_APIGWSTAGE = 'HTTP_X_APIGWSTAGE'.freeze
+    HTTP_X_REQUESTID = 'HTTP_X_REQUEST_ID'.freeze
 
     attr_reader :event, :context
 
@@ -48,6 +48,8 @@ module Lamby
     def env_headers
       headers.transform_keys do |key|
         "HTTP_#{key.to_s.upcase.tr '-', '_'}"
+      end.tap do |hdrs|
+        hdrs[HTTP_X_REQUESTID] = request_id
       end
     end
 
@@ -82,6 +84,10 @@ module Lamby
 
     def server_protocol
       event.dig('requestContext', 'protocol') || 'HTTP/1.1'
+    end
+
+    def request_id
+      context.aws_request_id
     end
 
   end


### PR DESCRIPTION
I learned while reading the ActionDispatch::RequestId middleware (https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/request_id.rb) I noticed that it will only set it when the header is not present. We can get consistent CloudWatch logs by simply grabbing the context's request id and passing the header down. See attached screenshot. Fixes #22.

<img width="1260" alt="Screen Shot 2019-04-09 at 7 38 41 PM" src="https://user-images.githubusercontent.com/2381/55841911-3f7fa100-5aff-11e9-932a-5120cab1aba3.png">