### PR TITLE
Add overwrite flag to #to_env for conditional overwriting/inheriting …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v1.0.2
+
+#### Changed
+
+* Adds an optional 'overwrite' parameter to #to_env.
+
 ## v1.0.1
 
 #### Changed

--- a/lib/lamby/ssm_parameter_store.rb
+++ b/lib/lamby/ssm_parameter_store.rb
@@ -32,9 +32,9 @@ module Lamby
       @options = options
     end
 
-    def to_env
+    def to_env(overwrite: true)
       params.each do |param|
-        ENV[param.env] = param.value
+        overwrite ? ENV[param.env] = param.value : ENV[param.env] ||= param.value
       end
     end
 

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/test/ssm_parameter_store_test.rb
+++ b/test/ssm_parameter_store_test.rb
@@ -8,14 +8,32 @@ class SsmParameterStoreTest < LambySpec
 
   after { clear! }
 
-  it '#to_env' do
-    envs = klass.new path
-    stub_params(envs)
-    refute ENV.key?('FOO')
-    refute ENV.key?('BAR')
-    envs.to_env
-    ENV['FOO'].must_equal 'foo'
-    ENV['BAR'].must_equal 'bar'
+  describe '#to_env' do
+    before do
+      ENV['FOO'] = 'test'
+    end
+
+    it 'overwrites existing environment variables by default' do
+      envs = klass.new path
+      stub_params(envs)
+      assert ENV.key?('FOO')
+      refute ENV.key?('BAR')
+      envs.to_env
+
+      ENV['FOO'].must_equal 'foo'
+      ENV['BAR'].must_equal 'bar'
+    end
+
+    it 'does not overwrite existing environment variables when overwrite flag set to false' do
+      envs = klass.new path
+      stub_params(envs)
+      assert ENV.key?('FOO')
+      refute ENV.key?('BAR')
+      envs.to_env(overwrite: false)
+
+      ENV['FOO'].must_equal 'test'
+      ENV['BAR'].must_equal 'bar'
+    end
   end
 
   it '#to_dotenv' do


### PR DESCRIPTION
### Description

Hey CustomInk folks! I've found the Lamby::SsmParameterStore super helpful in extracting some environment variables to AWS Parameter Store. It would be great to have a bit more control over whether #to_env overwrites pre-set environment variables. By default it seems to overwrite everything. This change adds an optional overwrite flag to #to_env. Existing functionality will not change since it defaults to true, but passing "overwrite: false" to #to_env will preserve any already-set variables in ENV.

### Changes

Code change: Adds an overwrite parameter to #to_env in Lamby::SsmParameterStore defaulted to true. Without passing the variable, all existing behavior is retained. If the variable is passed in as false, #to_env will preserve an existing ENV value.

