### PR TITLE
Update travis setup to fix CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - pyenv install --skip-existing $(cat .python-version)
   - sudo apt-get install python3-pip python3-dev
   - pip3 install pipenv
-  - sudo gem install bundler -v 1.17.3
+  - which bundle
   - bundle install
   - pipenv install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - sudo apt-get install python3-pip python3-dev
   - pip3 install pipenv
   - sudo gem install bundler -v 1.17.3
-  - bin/setup
+  - bundle install
+  - pipenv install
 script:
   - bin/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_script:
   - pyenv install --skip-existing $(cat .python-version)
   - sudo apt-get install python3-pip python3-dev
   - pip3 install pipenv
-  - which bundle
-  - bundle install
-  - pipenv install
+  - bin/setup
 script:
   - bin/test


### PR DESCRIPTION
## Issue
It looks like the `bin/setup` script is causing travis to switch to using system ruby instead of rvm's version. Possibly `set -e` is what's causing the issue.

```
$ rvm use 2.5.5 --install --binary --fuzzy
...
$ ruby --version
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux]
...
$ bin/setup
Fetching gem metadata from https://rubygems.org/............
zeitwerk-2.2.2 requires ruby version >= 2.4.4, which is incompatible with the
current version, ruby 2.3.1p112
The command "bin/setup" failed and exited with 5 during .
```

https://github.com/customink/lamby/blob/master/bin/setup#L1-L6

## Fix

This fix is a hack to try and get the travis setup run properly. It's duplicating the required setup commands in `bin/setup` in the `.travis.yml.`

The alternative would be to add conditionals in the `bin/setup` script to handle setup in the CI environment vs. a dev or deployed environment. I don't currently know enough about travis/rvm to offer that solution. 

This fix is untested. Hopefully it will just work :tm:.
