### PR TITLE
Only load the railtie if Rails is defined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+<!-- -*- mode: markdown -*- -->
 # Keep A Changelog!
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
+
+## Unreleased
+
+#### Changed
+
+* Only load the railtie if `Rails` is defined.
 
 ## v2.0.1
 

--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -10,8 +10,11 @@ require 'lamby/rack_rest'
 require 'lamby/rack_http'
 require 'lamby/debug'
 require 'lamby/handler'
-require 'rails/railtie'
-require 'lamby/railtie'
+
+if defined?(Rails)
+  require 'rails/railtie'
+  require 'lamby/railtie'
+end
 
 module Lamby
 


### PR DESCRIPTION
### Description

* This allows for Lamby to work "out of the box" for non-rails projects.

### Changes

* Conditionally load the railtie based on the presence of the `Rails` constant.
* Include a [file variable](https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html) for Emacs to load the Markdown mode over the Changelog mode. 
