### PR TITLE
Remove ActiveSupport and Rails Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ See this http://keepachangelog.com link for information on how we want this docu
 
 #### Changed
 
-* Remove depdency on `activesupport` for rack-only applications.
-* **breaking change** - Remove dependency on Rails for debug mode. No longer factor `Rails.env.development?` into the debug condition.
+* Remove dependency on `activesupport` for rack-only applications.
+* Remove ActiveSupport artifacts:
+  - Replace `strip_heredoc` with `<<~HEREDOC`.
+  - Remove instances of `Object#try`, replace with `&.`.
+  - Use `Rack::Utils.build_query` in place of `Object#to_query`.
+  - Replace `Object#present?` with `to_s.empty?`.
+  - Replace `Array.wrap` with `Array[obj].compact.flatten`.
+* Add a check against the `RAILS_ENV` AND `RACK_ENV` environment
+  variables prior to enabling debug mode.
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ See this http://keepachangelog.com link for information on how we want this docu
 * Remove ActiveSupport artifacts:
   - Replace `strip_heredoc` with `<<~HEREDOC`.
   - Remove instances of `Object#try`, replace with `&.`.
-  - Use `Rack::Utils.build_query` in place of `Object#to_query`.
+  - Use `Rack::Utils.build_nested_query` in place of `Object#to_query`.
   - Replace `Object#present?` with `to_s.empty?`.
   - Replace `Array.wrap` with `Array[obj].compact.flatten`.
 * Add a check against the `RAILS_ENV` AND `RACK_ENV` environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## Unreleased
+
+#### Changed
+
+* Remove depdency on `activesupport` for rack-only applications.
+* **breaking change** - Remove dependency on Rails for debug mode. No longer factor `Rails.env.development?` into the debug condition.
+
 ## v2.1.0
 
 #### Changed
@@ -29,7 +36,7 @@ Support for new API Gateway HTTP APIs!!!
 
 #### Added
 
-* New reack handler for HTTP API v1 and v2.
+* New rack handler for HTTP API v1 and v2.
 * Lots of backfill tests for, ALBs & REST APIs.
 
 

--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -1,7 +1,6 @@
 require 'lamby/logger'
 require 'rack'
 require 'base64'
-require 'active_support/all'
 require 'lamby/version'
 require 'lamby/sam_helpers'
 require 'lamby/rack'

--- a/lib/lamby/debug.rb
+++ b/lib/lamby/debug.rb
@@ -6,7 +6,7 @@ module Lamby
 
     def on?(event)
       params = event['multiValueQueryStringParameters'] || event['queryStringParameters']
-      ENV['LAMBY_DEBUG'] && params && params['debug'] == '1'
+      (development? && ENV['LAMBY_DEBUG']) && params && params['debug'] == '1'
     end
 
     def call(event, context, env)
@@ -40,6 +40,13 @@ module Lamby
           </body>
         </html>
       HTML
+    end
+
+    def development?
+      ENV
+        .slice('RACK_ENV', 'RAILS_ENV')
+        .values
+        .any? { |v| v.casecmp('development').zero? }
     end
 
   end

--- a/lib/lamby/debug.rb
+++ b/lib/lamby/debug.rb
@@ -6,7 +6,7 @@ module Lamby
 
     def on?(event)
       params = event['multiValueQueryStringParameters'] || event['queryStringParameters']
-      (Rails.env.development? || ENV['LAMBY_DEBUG']) && params && params['debug'] == '1'
+      ENV['LAMBY_DEBUG'] && params && params['debug'] == '1'
     end
 
     def call(event, context, env)

--- a/lib/lamby/debug.rb
+++ b/lib/lamby/debug.rb
@@ -6,7 +6,7 @@ module Lamby
 
     def on?(event)
       params = event['multiValueQueryStringParameters'] || event['queryStringParameters']
-      (development? && ENV['LAMBY_DEBUG']) && params && params['debug'] == '1'
+      (development? || ENV['LAMBY_DEBUG']) && params && params['debug'] == '1'
     end
 
     def call(event, context, env)
@@ -46,7 +46,7 @@ module Lamby
       ENV
         .slice('RACK_ENV', 'RAILS_ENV')
         .values
-        .any? { |v| v.casecmp('development').zero? }
+        .any? { |v| v.to_s.casecmp('development').zero? }
     end
 
   end

--- a/lib/lamby/rack.rb
+++ b/lib/lamby/rack.rb
@@ -71,9 +71,18 @@ module Lamby
           value.map{ |v| "#{key}=#{v}" }.join('&')
         end.flatten.join('&')
       else
-        query = event['queryStringParameters']
-        query && Rack::Utils.build_query(query)
+        build_query_string
       end
+    end
+
+    def build_query_string
+      return if event['queryStringParameters'].nil?
+
+      Rack::Utils.build_nested_query(
+        event.fetch('queryStringParameters')
+      )
+        .gsub('[', '%5B')
+        .gsub(']', '%5D')
     end
 
     def base64_encoded?

--- a/lib/lamby/rack.rb
+++ b/lib/lamby/rack.rb
@@ -71,7 +71,8 @@ module Lamby
           value.map{ |v| "#{key}=#{v}" }.join('&')
         end.flatten.join('&')
       else
-        event['queryStringParameters'].try(:to_query)
+        query = event['queryStringParameters']
+        query && Rack::Utils.build_query(query)
       end
     end
 

--- a/lib/lamby/rack_alb.rb
+++ b/lib/lamby/rack_alb.rb
@@ -11,7 +11,7 @@ module Lamby
 
     def response(handler)
       hhdrs = handler.headers
-      multivalue_headers = hhdrs.transform_values { |v| Array.wrap(v) } if multi_value?
+      multivalue_headers = hhdrs.transform_values { |v| Array[v].compact.flatten } if multi_value?
       status_description = "#{handler.status} #{::Rack::Utils::HTTP_STATUS_CODES[handler.status]}"
       base64_encode = hhdrs['Content-Transfer-Encoding'] == 'binary' || hhdrs['X-Lamby-Base64'] == '1'
       body = Base64.strict_encode64(handler.body) if base64_encode

--- a/lib/lamby/rack_http.rb
+++ b/lib/lamby/rack_http.rb
@@ -38,7 +38,7 @@ module Lamby
 
     def env_headers
       super.tap do |hdrs|
-        if event['cookies'].present?
+        if !event['cookies'].to_s.empty?
           hdrs[HTTP_COOKIE] = event['cookies'].join('; ')
         end
       end

--- a/lib/lamby/rack_http.rb
+++ b/lib/lamby/rack_http.rb
@@ -38,14 +38,18 @@ module Lamby
 
     def env_headers
       super.tap do |hdrs|
-        if !event['cookies'].to_s.empty?
-          hdrs[HTTP_COOKIE] = event['cookies'].join('; ')
+        if cookies.any?
+          hdrs[HTTP_COOKIE] = cookies.join('; ')
         end
       end
     end
 
     def request_method
       event.dig('requestContext', 'http', 'method') || event['httpMethod']
+    end
+
+    def cookies
+      event['cookies'] || []
     end
 
     # Using custom domain names with v1.0 yields a good `path` parameter sans

--- a/lib/lamby/ssm_parameter_store.rb
+++ b/lib/lamby/ssm_parameter_store.rb
@@ -19,9 +19,10 @@ module Lamby
         parts = path.from(1).split('/')
         env = parts.pop
         path = "/#{parts.join('/')}"
-        new(path).get!.params.detect do |p|
+        param = new(path).get!.params.detect do |p|
           p.env == env
-        end.try(:value)
+        end
+        param&.value
       end
 
     end
@@ -44,7 +45,7 @@ module Lamby
 
     def get!
       get_all!
-      get_history! if label.present?
+      get_history! unless label.to_s.empty?
       self
     end
 
@@ -98,7 +99,7 @@ module Lamby
         with_decryption: true,
         max_results: MAX_RESULTS
       }.tap { |options|
-        token = @all_response.try(:next_token)
+        token = @all_response&.next_token
         options[:next_token] = token if token
       }
     end
@@ -137,7 +138,7 @@ module Lamby
         with_decryption: true,
         max_results: MAX_RESULTS
       }.tap { |options|
-        token = @hist_response.try(:next_token)
+        token = @hist_response&.next_token
         options[:next_token] = token if token
       }
     end

--- a/lib/lamby/templates/alb.rb
+++ b/lib/lamby/templates/alb.rb
@@ -10,7 +10,7 @@ gsub_file app_file('template.yaml'), /APPNAMEHERE/, appname
 
 say 'Adding to .gitignore...'
 FileUtils.touch app_file('.gitignore')
-append_to_file app_file('.gitignore'), <<-GITIGNORE.strip_heredoc
+append_to_file app_file('.gitignore'), <<~GITIGNORE
   # Lamby
   /.aws-sam
 GITIGNORE

--- a/lib/lamby/templates/http.rb
+++ b/lib/lamby/templates/http.rb
@@ -10,7 +10,7 @@ gsub_file app_file('template.yaml'), /APPNAMEHERE/, appname
 
 say 'Adding to .gitignore...'
 FileUtils.touch app_file('.gitignore')
-append_to_file app_file('.gitignore'), <<-GITIGNORE.strip_heredoc
+append_to_file app_file('.gitignore'), <<~GITIGNORE
   # Lamby
   /.aws-sam
 GITIGNORE

--- a/lib/lamby/templates/rest.rb
+++ b/lib/lamby/templates/rest.rb
@@ -10,7 +10,7 @@ gsub_file app_file('template.yaml'), /APPNAMEHERE/, appname
 
 say 'Adding to .gitignore...'
 FileUtils.touch app_file('.gitignore')
-append_to_file app_file('.gitignore'), <<-GITIGNORE.strip_heredoc
+append_to_file app_file('.gitignore'), <<~GITIGNORE
   # Lamby
   /.aws-sam
 GITIGNORE

--- a/test/debug_test.rb
+++ b/test/debug_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class DebugTest < LambySpec
+  describe '#on?' do
+    let(:event) do
+      TestHelpers::Events::HttpV2.create(
+        'queryStringParameters' => {
+          'debug' => debug_param
+        }
+      )
+    end
+
+    before do
+      @old_env = ENV
+      ENV['LAMBY_DEBUG'] = '1'
+    end
+
+    after { ENV.replace(@old_env) }
+
+    describe 'when RACK_ENV == development' do
+      before { ENV['RACK_ENV'] = 'development' }
+
+      describe 'when the debug param is 1' do
+        let(:debug_param) { '1' }
+
+        it 'returns true' do
+          expect(Lamby::Debug.on?(event)).must_equal true
+        end
+      end
+
+      describe 'when the debug param is nil' do
+        let(:debug_param) { nil }
+
+        it 'returns false' do
+          expect(Lamby::Debug.on?(event)).must_equal false
+        end
+      end
+    end
+
+    describe 'when RAILS_ENV == development' do
+      before { ENV['RAILS_ENV'] = 'development' }
+
+      describe 'when the debug param is 1' do
+        let(:debug_param) { '1' }
+
+        it 'returns true' do
+          expect(Lamby::Debug.on?(event)).must_equal true
+        end
+      end
+
+      describe 'when the debug param is nil' do
+        let(:debug_param) { nil }
+
+        it 'returns false' do
+          expect(Lamby::Debug.on?(event)).must_equal false
+        end
+      end
+    end
+  end
+end

--- a/test/debug_test.rb
+++ b/test/debug_test.rb
@@ -11,14 +11,20 @@ class DebugTest < LambySpec
     end
 
     before do
-      @old_env = ENV
-      ENV['LAMBY_DEBUG'] = '1'
+      @old_rack_env = ENV['RACK_ENV']
+      @old_rails_env = ENV['RAILS_ENV']
+      ENV['RACK_ENV'] = rack_env
+      ENV['RAILS_ENV'] = rails_env
     end
 
-    after { ENV.replace(@old_env) }
+    after do
+      ENV['RACK_ENV'] = @old_rack_env
+      ENV['RAILS_ENV'] = @old_rails_env
+    end
 
     describe 'when RACK_ENV == development' do
-      before { ENV['RACK_ENV'] = 'development' }
+      let(:rack_env) { 'development' }
+      let(:rails_env) { nil }
 
       describe 'when the debug param is 1' do
         let(:debug_param) { '1' }
@@ -38,7 +44,8 @@ class DebugTest < LambySpec
     end
 
     describe 'when RAILS_ENV == development' do
-      before { ENV['RAILS_ENV'] = 'development' }
+      let(:rack_env) { 'production' }
+      let(:rails_env) { 'development' }
 
       describe 'when the debug param is 1' do
         let(:debug_param) { '1' }

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -7,7 +7,7 @@ class IntegrationTest < LambySpec
     expect(out).must_include 'API Gateway (HTTP API) installer'
     # Handler
     assert File.exists?(dummy_handler)
-    expect(File.read(dummy_handler)).must_include <<-RUBY.strip_heredoc
+    expect(File.read(dummy_handler)).must_include <<~RUBY
       def handler(event:, context:)
         Lamby.handler $app, event, context, rack: :http
       end
@@ -30,7 +30,7 @@ class IntegrationTest < LambySpec
     expect(out).must_include 'API Gateway (REST API) installer'
     # Handler
     assert File.exists?(dummy_handler)
-    expect(File.read(dummy_handler)).must_include <<-RUBY.strip_heredoc
+    expect(File.read(dummy_handler)).must_include <<~RUBY
       def handler(event:, context:)
         Lamby.handler $app, event, context, rack: :rest
       end

--- a/test/ssm_parameter_store_test.rb
+++ b/test/ssm_parameter_store_test.rb
@@ -38,7 +38,7 @@ class SsmParameterStoreTest < LambySpec
     envs = klass.new path, dotenv_file: file
     stub_params(envs)
     envs.to_dotenv
-    expect(File.read(file)).must_equal <<-EOF.strip_heredoc
+    expect(File.read(file)).must_equal <<~EOF
       FOO=foo
       BAR=bar
     EOF


### PR DESCRIPTION
## Description

Hi There,

Thanks for making a great library! I was looking for something just like Lamby as I started a new serverless project.

I'm hoping to use Lamby with a standard rack/Sinatra app and noticed there were hard dependencies on Rails and ActiveSupport. 

The Lamby code doesn't appear to be using any ActiveSupport features, and it looks like recent PRs helped remove some other hard dependencies on Rails, so I decided to submit this PR!

## Notes

* `Rails.env.development?` was used in the conditional for
  determining if debug handler should be called (in conjunction
  with the `debug=1` parameter). Remove the conditional check
  as it represented a hard dependency on Rails and failed for
  non-Rails applications.
* Remove the load of `activesupport/all` as it is not specified
  as a dependency in the `.gemspec` and is not used directly in
  the gem.
