### PR TITLE
bin/rails webpacker:compile optiion in _build

### DIFF
--- a/lib/lamby/templates/alb/_build
+++ b/lib/lamby/templates/alb/_build
@@ -31,6 +31,10 @@ echo "== Asset Hosts & Precompiling =="
 #   RAILS_GROUPS=assets \
 #   ./bin/rails assets:precompile
 
+echo "== Webpack & Precompiling =="
+#NODE_ENV='production' \
+# ./bin/rails webpacker:compile
+
 echo "== Cleanup Unused Files & Directories =="
 rm -rf \
   log \

--- a/lib/lamby/templates/http/_build
+++ b/lib/lamby/templates/http/_build
@@ -31,6 +31,10 @@ echo "== Asset Hosts & Precompiling =="
 #   RAILS_GROUPS=assets \
 #   ./bin/rails assets:precompile
 
+echo "== Webpack & Precompiling =="
+#NODE_ENV='production' \
+# ./bin/rails webpacker:compile
+
 echo "== Cleanup Unused Files & Directories =="
 rm -rf \
   log \

--- a/lib/lamby/templates/rest/_build
+++ b/lib/lamby/templates/rest/_build
@@ -31,6 +31,10 @@ echo "== Asset Hosts & Precompiling =="
 #   RAILS_GROUPS=assets \
 #   ./bin/rails assets:precompile
 
+echo "== Webpack & Precompiling =="
+#NODE_ENV='production' \
+# ./bin/rails webpacker:compile
+
 echo "== Cleanup Unused Files & Directories =="
 rm -rf \
   log \

--- a/test/dummy_app/bin/_build
+++ b/test/dummy_app/bin/_build
@@ -31,6 +31,10 @@ echo "== Asset Hosts & Precompiling =="
 #   RAILS_GROUPS=assets \
 #   ./bin/rails assets:precompile
 
+echo "== Webpack & Precompiling =="
+#NODE_ENV='production' \
+# ./bin/rails webpacker:compile
+
 echo "== Cleanup Unused Files & Directories =="
 rm -rf \
   log \


### PR DESCRIPTION
### Description

currently the `bin/_build` and the https://lamby.custominktech.com/docs/asset_host_and_precompiling describe only `sprockets` asset compilation. Rails 6 have webpacker by default to replace JavaScript compilation of sprockets. 

So I think it's worth to include `webpacker:compile` lines in the `bin/_build` 

I'm also planing to do PR on docs in https://lamby.custominktech.com/docs/asset_host_and_precompiling to include Webpacker section

### Changes

I'm updating any occurrence of `bin/_build` in the project (don't have full understanding where it's really needed, so pls let me know if I've overkilled it, I can change PR) 

### Screenshots

here is proof that it works


https://ror.serverless-ruby.org/

https://github.com/equivalent/my_awesome_lambda-lamby/blob/master/app/javascript/controllers/hello_controller.js
https://github.com/equivalent/my_awesome_lambda-lamby/blob/master/app/views/layouts/application.html.erb#L18

![Screenshot from 2021-01-11 00-06-27](https://user-images.githubusercontent.com/721990/104137940-e19d7e80-53a0-11eb-806a-e69f8a0d9b63.png)

