### PR TITLE
Fix Quoting in describe-subnets

### DIFF
--- a/lib/lamby/templates/alb/_deploy
+++ b/lib/lamby/templates/alb/_deploy
@@ -21,7 +21,7 @@ export VPCID=${VPCID:=$(
 export SUBNETS=${SUBNETS:=$(
   aws ec2 describe-subnets \
     --output text \
-    --filters "Name=state,Values=available,Name=vpc-id,Values=$VPCID" \
+    --filters 'Name=state,Values=available' "Name=vpc-id,Values=$VPCID" \
     --query 'Subnets[*].SubnetId' | \
     tr -s '[:blank:]' ','
 )}


### PR DESCRIPTION
### Description

When running the alb deploy script, I get the following error.

```
export SUBNETS=${SUBNETS:=$(
  aws ec2 describe-subnets \
    --output text \
    --filters "Name=state,Values=available,Name=vpc-id,Values=$VPCID" \
    --query 'Subnets[*].SubnetId' | \
    tr -s '[:blank:]' ','
)}
```

> Error parsing parameter '--filters': Second instance of key "Name" encountered for input:
Name=state,Values=available,Name=vpc-id,Values=

### Changes

This PR fixes the quoting issue so the command is successful and the subnets are properly assigned to SUBNETS.