### PR TITLE
[Misc] Open dot env file in append mode

### DIFF
--- a/lib/lamby/ssm_parameter_store.rb
+++ b/lib/lamby/ssm_parameter_store.rb
@@ -40,7 +40,7 @@ module Lamby
     end
 
     def to_dotenv
-      File.open(dotenv_file, 'w') { |f| f.write(dotenv_contents) }
+      File.open(dotenv_file, 'a') { |f| f.write(dotenv_contents) }
     end
 
     def get!


### PR DESCRIPTION
### Description

Currently loading secure configs using SSM Parameter store via https://github.com/customink/lamby/blob/master/lib/lamby/ssm_parameter_store.rb#L42-L44 opens relevant dot env file in write mode which overwrites any existing dot env file content of the same name.

Often dot env files has both secure configs (e.g tokens etc) and environment specific endpoint configs. This PR opens the dot env file in appends mode when fetching secure configs from SSM store which allows client rails apps to check-in environment specific dot env files with configs that doesn't need to be secure. 

### Changes

* Open dot env file in append mode
