### PR TITLE
Base64 encode response body if the rack response is compressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v2.5.3
+
+#### Fixed
+
+* Base64 encode response body if the rack response is gzip or brotli compressed.
+
 ## v2.5.2
 
 * SSM file always overwrites. Fixes #65.

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -47,6 +47,7 @@ module Lamby
     def base64_encodeable?
       @headers && (
         @headers['Content-Transfer-Encoding'] == 'binary' ||
+        content_encoding_compressed? ||
         @headers['X-Lamby-Base64'] == '1'
       )
     end
@@ -80,5 +81,9 @@ module Lamby
       end
     end
 
+    def content_encoding_compressed?
+      content_encoding_header = @headers['Content-Encoding'] || ''
+      content_encoding_header.split(', ').any? { |h| ['br', 'gzip'].include?(h) }
+    end
   end
 end

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '2.5.2'
+  VERSION = '2.5.3'
 end


### PR DESCRIPTION
### Description

Currently Rack responses that are compressed to either `gzip` or `br` (Brotli) encodings will be passed by Lamby to AWS Ruby runtime client which fails to parse encoding with the following error. This is due to AWS Runtime Client by default, running `to_json` on handler response value
More info here - https://github.com/aws/aws-lambda-ruby-runtime-interface-client/blob/5e669fe30b48362cac758bc2d2c161787adb2e84/lib/aws_lambda_ric/aws_lambda_marshaller.rb#L30
```
Error raised from handler method
"errorMessage": "\"\\x8B\" from ASCII-8BIT to UTF-8",
"errorType": "Function<Encoding::UndefinedConversionError>",
```
Base64 encoding response body before handing over to AWS runtime client will solve the issue. 

Note: Lamby already recommends setting `X-Lamby-Base64` header to indicate rack adapter that the content requires base64 binary encoding here - https://lamby.custominktech.com/docs/asset_host_and_precompiling. 
Perhaps this PR will prevent the need for setting that header altogether? @metaskills 

### Changes
* Base64 encode response body if the rack response is `gzip` or `brotli` compressed
