### PR TITLE
Forward SSH agent on macOS

### DIFF
--- a/lib/lamby/templates/alb/deploy
+++ b/lib/lamby/templates/alb/deploy
@@ -3,6 +3,10 @@ set -e
 
 export RAILS_ENV=${RAILS_ENV:=production}
 
+if [[ "$OSTYPE" == *"darwin"* ]]; then
+  export SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+fi
+
 docker-compose run \
    -e CLOUDFORMATION_BUCKET \
    cicd \

--- a/lib/lamby/templates/http/deploy
+++ b/lib/lamby/templates/http/deploy
@@ -3,6 +3,10 @@ set -e
 
 export RAILS_ENV=${RAILS_ENV:=production}
 
+if [[ "$OSTYPE" == *"darwin"* ]]; then
+  export SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+fi
+
 docker-compose run \
    -e CLOUDFORMATION_BUCKET \
    cicd \

--- a/lib/lamby/templates/rest/deploy
+++ b/lib/lamby/templates/rest/deploy
@@ -3,6 +3,10 @@ set -e
 
 export RAILS_ENV=${RAILS_ENV:=production}
 
+if [[ "$OSTYPE" == *"darwin"* ]]; then
+  export SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+fi
+
 docker-compose run \
    -e CLOUDFORMATION_BUCKET \
    cicd \


### PR DESCRIPTION
This is already implemented in cookiecutter, just copying code back to Lamby.
