### PR TITLE
Removing dotenv requirement

### DIFF
--- a/lib/lamby/templates/alb/app.rb
+++ b/lib/lamby/templates/alb/app.rb
@@ -1,6 +1,5 @@
 ENV['RAILS_SERVE_STATIC_FILES'] = '1'
 require_relative 'config/boot'
-require 'dotenv' ; Dotenv.load ".env.#{ENV['RAILS_ENV']}"
 require 'lamby'
 require_relative 'config/application'
 require_relative 'config/environment'

--- a/lib/lamby/templates/http/app.rb
+++ b/lib/lamby/templates/http/app.rb
@@ -1,6 +1,5 @@
 ENV['RAILS_SERVE_STATIC_FILES'] = '1'
 require_relative 'config/boot'
-require 'dotenv' ; Dotenv.load ".env.#{ENV['RAILS_ENV']}"
 require 'lamby'
 require_relative 'config/application'
 require_relative 'config/environment'

--- a/lib/lamby/templates/rest/app.rb
+++ b/lib/lamby/templates/rest/app.rb
@@ -1,6 +1,5 @@
 ENV['RAILS_SERVE_STATIC_FILES'] = '1'
 require_relative 'config/boot'
-require 'dotenv' ; Dotenv.load ".env.#{ENV['RAILS_ENV']}"
 require 'lamby'
 require_relative 'config/application'
 require_relative 'config/environment'


### PR DESCRIPTION
Gemspec is not defining dotenv dependency and I don't find any other reference to it, so requiring it fails right now.
I guess this might be originating from the cookiecutter project where it's actually included in the Gemfile.

(Sorry for all the PR's, but I'm unsure if these changes are welcome or not)