### PR TITLE
Support Multiple Set-Cookie Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v2.6.0
+
+#### Fixed
+
+* Support multiple Set-Cookie headers for all rest types.
+
 ## v2.5.3
 
 #### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (2.5.3)
+    lamby (2.6.0)
       rack
 
 GEM

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -31,6 +31,13 @@ module Lamby
       @headers
     end
 
+    def set_cookies
+      return @set_cookies if defined?(@set_cookies)
+      @set_cookies = if @headers && @headers['Set-Cookie']
+        @headers.delete('Set-Cookie').split("\n")
+      end
+    end
+
     def body
       @rbody ||= ''.tap do |rbody|
         @body.each { |part| rbody << part }
@@ -40,6 +47,7 @@ module Lamby
     def call
       return self if @called
       @status, @headers, @body = call_app
+      set_cookies
       @called = true
       self
     end

--- a/lib/lamby/rack_alb.rb
+++ b/lib/lamby/rack_alb.rb
@@ -11,7 +11,10 @@ module Lamby
 
     def response(handler)
       hhdrs = handler.headers
-      multivalue_headers = hhdrs.transform_values { |v| Array[v].compact.flatten } if multi_value?
+      if multi_value?
+        multivalue_headers = hhdrs.transform_values { |v| Array[v].compact.flatten }
+        multivalue_headers['Set-Cookie'] = handler.set_cookies if handler.set_cookies
+      end
       status_description = "#{handler.status} #{::Rack::Utils::HTTP_STATUS_CODES[handler.status]}"
       base64_encode = hhdrs['Content-Transfer-Encoding'] == 'binary' || hhdrs['X-Lamby-Base64'] == '1'
       body = Base64.strict_encode64(handler.body) if base64_encode

--- a/lib/lamby/rack_http.rb
+++ b/lib/lamby/rack_http.rb
@@ -6,6 +6,15 @@ module Lamby
         { isBase64Encoded: true, body: handler.body64 }
       else
         super
+      end.tap do |r|
+        if cookies = handler.set_cookies
+          if payload_version_one?
+            r[:multiValueHeaders] ||= {}
+            r[:multiValueHeaders]['Set-Cookie'] = cookies
+          else
+            r[:cookies] = cookies
+          end
+        end
       end
     end
 
@@ -79,6 +88,9 @@ module Lamby
         'HTTP/1.1'
     end
 
+    def payload_version_one?
+      event['version'] == '1.0'
+    end
 
   end
 end

--- a/lib/lamby/rack_rest.rb
+++ b/lib/lamby/rack_rest.rb
@@ -6,6 +6,11 @@ module Lamby
         { isBase64Encoded: true, body: handler.body64 }
       else
         super
+      end.tap do |r|
+        if cookies = handler.set_cookies
+          r[:multiValueHeaders] ||= {}
+          r[:multiValueHeaders]['Set-Cookie'] = cookies
+        end
       end
     end
 

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '2.5.3'
+  VERSION = '2.6.0'
 end

--- a/test/dummy_app/app/controllers/application_controller.rb
+++ b/test/dummy_app/app/controllers/application_controller.rb
@@ -26,6 +26,12 @@ class ApplicationController < ActionController::Base
     raise 'hell'
   end
 
+  def cooks
+    cookies['1'] = '1'
+    cookies['2'] = '2'
+    render :index
+  end
+
   private
 
   def logged_in?

--- a/test/dummy_app/config/routes.rb
+++ b/test/dummy_app/config/routes.rb
@@ -4,4 +4,5 @@ Dummy::Application.routes.draw do
   post 'login', to: 'application#login'
   delete 'logout', to: 'application#logout'
   get 'exception', to: 'application#exception'
+  get 'cooks', to: 'application#cooks'
 end


### PR DESCRIPTION
API Gateway has supported multi-value parameters (https://aws.amazon.com/about-aws/whats-new/2018/10/amazon-api-gateway-adds-support-for-multi-parameters/) for some time. This includes response headers such as `Set-Cookie` for both REST API and HTTP API. Even ALB integrations support this:

* https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
* https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format

This article (https://medium.com/@lancers/amazon-api-gateway-explaining-lambda-payload-version-2-0-in-http-api-24b0b4db5d36) does a really good job of breaking down the two AWS references docs.

The problem? Rack's HTTP spec (https://github.com/rack/rack/blob/master/SPEC.rdoc#the-headers-) for multiple values in a single `Set-Cookie` header is to join them with a `\n` new line character. We can not pass this as is to API Gateway or an ALB. Instead we pull the `Set-Cookie` header from the standard `headers` response and instead pass it via the proper interface of `cookies` or `multiValueHeaders ` as needed.