### PR TITLE
Rescue no method error when response body is nil from 301 redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,84 @@
 <!-- -*- mode: markdown -*- -->
+
 # Keep A Changelog!
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
+
+## v2.6.1
+
+#### Fixed
+
+- Support redirects with empty response body.
+
+#### Added
+
+- Tests for enabling Rack::Deflate middleware by passing RACK_DEFLATE_ENABLED env variable.
 
 ## v2.6.0
 
 #### Fixed
 
-* Support multiple Set-Cookie headers for all rest types.
+- Support multiple Set-Cookie headers for all rest types.
 
 ## v2.5.3
 
 #### Fixed
 
-* Base64 encode response body if the rack response is gzip or brotli compressed.
+- Base64 encode response body if the rack response is gzip or brotli compressed.
 
 ## v2.5.2
 
-* SSM file always overwrites. Fixes #65.
+- SSM file always overwrites. Fixes #65.
 
 ## v2.5.1
 
 #### Fixed
 
-* Quoting in describe-subnets #62 Thanks @atwoodjw
+- Quoting in describe-subnets #62 Thanks @atwoodjw
 
 ## v2.5.0
 
 #### Changed
 
-* Install files to favor containers.
+- Install files to favor containers.
 
 ## v2.2.2
 
 #### Changed
 
-* More ActiveSupport removal. Better ENV.to_h.
+- More ActiveSupport removal. Better ENV.to_h.
 
 ## v2.2.1
 
 #### Changed
 
-* More ActiveSupport removal from SsmParameterStore.
+- More ActiveSupport removal from SsmParameterStore.
 
 ## v2.2.0
 
 #### Changed
 
-* Remove dependency on `activesupport` for rack-only applications.
-* Remove ActiveSupport artifacts:
+- Remove dependency on `activesupport` for rack-only applications.
+- Remove ActiveSupport artifacts:
   - Replace `strip_heredoc` with `<<~HEREDOC`.
   - Remove instances of `Object#try`, replace with `&.`.
   - Use `Rack::Utils.build_nested_query` in place of `Object#to_query`.
   - Replace `Object#present?` with `to_s.empty?`.
   - Replace `Array.wrap` with `Array[obj].compact.flatten`.
-* Add a check against the `RAILS_ENV` AND `RACK_ENV` environment
+- Add a check against the `RAILS_ENV` AND `RACK_ENV` environment
   variables prior to enabling debug mode.
 
 ## v2.1.0
 
 #### Changed
 
-* Only load the railtie if `Rails` is defined.
+- Only load the railtie if `Rails` is defined.
 
 ## v2.0.1
 
 #### Changed
 
-* Remove Rails runtime dep. Only rack is needed.
+- Remove Rails runtime dep. Only rack is needed.
 
 ## v2.0.0
 
@@ -75,120 +86,107 @@ Support for new API Gateway HTTP APIs!!!
 
 #### Changed
 
-* The `Lamby.handler` must have a `:rack` option. One of `:http`, `:rest`, `:alb`.
-* Renamed template generators to match options above.
-* The `lamby:install` task now defaults to HTTP API.
-* Changed the name of `:api` rack option to `:rest`.
-* Removed `export` from Dotenv files. Better Docker compatability.
+- The `Lamby.handler` must have a `:rack` option. One of `:http`, `:rest`, `:alb`.
+- Renamed template generators to match options above.
+- The `lamby:install` task now defaults to HTTP API.
+- Changed the name of `:api` rack option to `:rest`.
+- Removed `export` from Dotenv files. Better Docker compatability.
 
 #### Added
 
-* New rack handler for HTTP API v1 and v2.
-* Lots of backfill tests for, ALBs & REST APIs.
-
+- New rack handler for HTTP API v1 and v2.
+- Lots of backfill tests for, ALBs & REST APIs.
 
 ## v1.0.3
 
 #### Changed
 
-* Change shebangs to `#!/usr/bin/env bash`
-
+- Change shebangs to `#!/usr/bin/env bash`
 
 ## v1.0.2
 
 #### Changed
 
-* Adds an optional 'overwrite' parameter to #to_env.
+- Adds an optional 'overwrite' parameter to #to_env.
 
 ## v1.0.1
 
 #### Changed
 
-* Links in bin/build templates to point to lamby.custominktech.com site.
-
+- Links in bin/build templates to point to lamby.custominktech.com site.
 
 ## v1.0.0
 
 #### Fixed
 
-* ALB query params & binary responses. Fixes #38.
-
+- ALB query params & binary responses. Fixes #38.
 
 ## v0.6.0
 
 #### Added
 
-* APPLICATION LOAD BALANACER SUPPORT!!! The new default. Use `rack: :api` option to handler for API Gateway support.
+- APPLICATION LOAD BALANACER SUPPORT!!! The new default. Use `rack: :api` option to handler for API Gateway support.
 
 #### Changed
 
-* Rake task `lamby:install` now defaults to `application_load_balancer`
-
+- Rake task `lamby:install` now defaults to `application_load_balancer`
 
 ## v0.5.1
 
 #### Fixed
 
-* The .gitignore file template. Fix .aws-sam dir.
-
+- The .gitignore file template. Fix .aws-sam dir.
 
 ## v0.5.0
 
 #### Added
 
-* Template generators for first install. Ex: `./bin/rake -r lamby lamby:install:api_gateway`.
-* New `Lamby::SsmParameterStore.get!` helper.
-
+- Template generators for first install. Ex: `./bin/rake -r lamby lamby:install:api_gateway`.
+- New `Lamby::SsmParameterStore.get!` helper.
 
 ## v0.4.1
 
 #### Fixed
 
-* Fix type in v0.4.0 fix below.
-
+- Fix type in v0.4.0 fix below.
 
 ## v0.4.0
 
 #### Fixed
 
-* File uploads in #33 using `CONTENT_TYPE` and `CONTENT_LENGTH`.
-
+- File uploads in #33 using `CONTENT_TYPE` and `CONTENT_LENGTH`.
 
 ## v0.3.2
 
 #### Added
 
-* Pass Request ID for CloudWatch logs. Fixes #30.
-
+- Pass Request ID for CloudWatch logs. Fixes #30.
 
 ## v0.3.1
 
 #### Changed
 
-* Docs and SAM template tweaks.
-
+- Docs and SAM template tweaks.
 
 ## v0.3.0
 
 #### Added
 
-* Secure configs rake task.
-* Project bin setup and tests.
+- Secure configs rake task.
+- Project bin setup and tests.
 
 #### Changed
 
-* SAM template tweaks.
-
+- SAM template tweaks.
 
 ## v0.2.0
 
 #### Changed
 
-* Simple docs and project re-organization.
-
+- Simple docs and project re-organization.
 
 ## v0.1.0
 
 #### Added
 
-* New gem and placeholder in rubygems.
+- New gem and placeholder in rubygems.

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,12 @@ Rake::TestTask.new(:test) do |t|
   t.warning = false
 end
 
-task :default => :test
+Rake::TestTask.new(:test_deflate) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/rack_deflate_test.rb"]
+  t.verbose = false
+  t.warning = false
+end
+
+task :default => [:test, :test_deflate]

--- a/bin/_test
+++ b/bin/_test
@@ -4,3 +4,4 @@ set -e
 export RAILS_ENV="test"
 
 bundle exec rake test
+RACK_DEFLATE_ENABLED=1 bundle exec rake test_deflate

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -40,7 +40,7 @@ module Lamby
 
     def body
       @rbody ||= ''.tap do |rbody|
-        @body.each { |part| rbody << part }
+        @body.each { |part| rbody << part if part }
       end
     end
 

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '2.6.0'
+  VERSION = '2.6.1'
 end

--- a/test/dummy_app/config/routes.rb
+++ b/test/dummy_app/config/routes.rb
@@ -5,4 +5,5 @@ Dummy::Application.routes.draw do
   delete 'logout', to: 'application#logout'
   get 'exception', to: 'application#exception'
   get 'cooks', to: 'application#cooks'
+  get 'redirect_test', to: redirect('/')
 end

--- a/test/dummy_app/init.rb
+++ b/test/dummy_app/init.rb
@@ -40,7 +40,7 @@ module Dummy
     config.dependency_loading = true
     config.preload_frameworks = true
     config.eager_load = true
-
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater, sync: false if ENV['RACK_DEFLATE_ENABLED']
   end
 end
 

--- a/test/rack_deflate_test.rb
+++ b/test/rack_deflate_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class RackDeflateTest < LambySpec
+
+  let(:app)     { Rack::Builder.new { run Rails.application }.to_app }
+  let(:context) { TestHelpers::LambdaContext.new }
+
+  describe 'Using Rack Deflate Middleware' do
+
+    it 'get' do
+      event = TestHelpers::Events::HttpV2.create
+      result = Lamby.handler app, event, context, rack: :http
+      expect(result[:statusCode]).must_equal 200
+    end
+
+    it 'get - test redirect' do
+      event = TestHelpers::Events::HttpV2.create(
+        'rawPath' => '/production/redirect_test',
+        'requestContext' => { 'http' => {'path' => '/production/redirect_test'} }
+      )
+      result = Lamby.handler app, event, context, rack: :http
+      expect(result[:statusCode]).must_equal 301
+      refute result[:headers]['Location'].nil?
+    end
+    
+  end
+  
+end


### PR DESCRIPTION
### Description

Currently a 301 response with a redirect location header and an empty body raise a `NoMethodError - undefined method empty? for nil:NilClass`. This is because the `@body` of `Rack::BodyProxy` is of `ActionDispatch::Response` type with buffer value set to `[nil]`.

#### Error
```

Error raised from handler method
--
{
"errorMessage": "no implicit conversion of nil into String",
"errorType": "Function<TypeError>",
"stackTrace": [
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby/handler.rb:43:in `block (2 levels) in body'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/actionpack-5.1.6.2/lib/action_dispatch/http/response.rb:145:in `each'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/actionpack-5.1.6.2/lib/action_dispatch/http/response.rb:145:in `each_chunk'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/actionpack-5.1.6.2/lib/action_dispatch/http/response.rb:126:in `each'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/actionpack-5.1.6.2/lib/action_dispatch/http/response.rb:74:in `each'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/actionpack-5.1.6.2/lib/action_dispatch/http/response.rb:473:in `each'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/rack-2.2.3/lib/rack/body_proxy.rb:41:in `method_missing'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/rack-2.2.3/lib/rack/body_proxy.rb:41:in `method_missing'",
"/var/task/vendor/bundle/ruby/2.5.0/gems/rack-2.2.3/lib/rack/body_proxy.rb:41:in `method_missing'",
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby/handler.rb:43:in `block in body'",
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby/handler.rb:42:in `tap'",
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby/handler.rb:42:in `body'",
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby/handler.rb:23:in `response'",
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby/handler.rb:7:in `call'",
"/var/task/vendor/bundle/ruby/2.5.0/bundler/gems/lamby-de0826a5b50d/lib/lamby.rb:23:in `handler'",
```

A 301 Response

```log
#<Rack::Deflater::GzipStream:0x0000555f8b431da0 @body=#<Rack::BodyProxy:0x0000555f8b4322f0 @body=#<Rack::BodyProxy:0x0000555f8b432390 @body=#<Rack::BodyProxy:0x0000555f8b432570 @body=#<ActionDispatch::Response::RackBody:0x0000555f8b433920 @stream=#<ActionDispatch::Response::Buffer:0x0000555f8b421928 @response=#<ActionDispatch::Response:0x0000555f8b3d2378 ...>, @buf=[nil], @closed=false, @str_body=nil>, @status=301
```

### Changes

* Handle response body being `nil` for a 301 response.

