### PR TITLE
Support Custom Lamby Events. Task Runner.

### DIFF
--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -8,6 +8,7 @@ require 'lamby/rack_alb'
 require 'lamby/rack_rest'
 require 'lamby/rack_http'
 require 'lamby/debug'
+require 'lamby/runner'
 require 'lamby/handler'
 
 if defined?(Rails)

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -47,7 +47,7 @@ module Lamby
     def call
       return self if @called
       @status, @headers, @body = call_app
-      set_cookies
+      set_cookies if rack?
       @called = true
       self
     end
@@ -84,6 +84,8 @@ module Lamby
     def call_app
       if Debug.on?(@event)
         Debug.call @event, @context, rack.env
+      elsif runner?
+        Runner.call(@event)
       else
         @app.call rack.env
       end
@@ -92,6 +94,14 @@ module Lamby
     def content_encoding_compressed?(hdrs)
       content_encoding_header = hdrs['Content-Encoding'] || ''
       content_encoding_header.split(', ').any? { |h| ['br', 'gzip'].include?(h) }
+    end
+
+    def runner?
+      Runner.handle?(@event)
+    end
+
+    def rack?
+      !runner?
     end
   end
 end

--- a/lib/lamby/runner.rb
+++ b/lib/lamby/runner.rb
@@ -1,0 +1,36 @@
+require 'open3'
+
+module Lamby
+  class Runner
+
+    class << self
+
+      def handle?(event)
+        event.dig 'lamby', 'runner'
+      end
+
+      def call(event)
+        new(event).call
+      end
+
+    end
+
+    def initialize(event)
+      @event = event
+    end
+
+    def call
+      status = Open3.popen3(command) do |_stdin, stdout, stderr, thread|
+        puts stdout.read
+        puts stderr.read
+        thread.value.exitstatus
+      end
+      [status, {}, StringIO.new('')]
+    end
+
+    def command
+      @event.dig 'lamby', 'runner'
+    end
+
+  end
+end

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -275,6 +275,19 @@ class HandlerTest < LambySpec
 
   end
 
+  describe 'runner' do
+
+    it 'pwd' do
+      event = { 'lamby' => { 'runner' => 'pwd' } }
+      out = capture(:stdout) { @result = Lamby.handler app, event, context, rack: :http }
+      expect(out).must_match %r{/var/task}
+      expect(@result[:statusCode]).must_equal 0
+      expect(@result[:headers]).must_equal({})
+      expect(@result[:body]).must_equal ""
+    end
+
+  end
+
   private
 
   def session_cookie(result)


### PR DESCRIPTION
Supporting migrations is the goal of this work but I decided to do something more abstract. The idea here is rather than get caught up in the semantics of how Rails v5.0 and up changes the way you could do this from code (https://stackoverflow.com/questions/7287250/run-migrations-from-rails-console) it is best to stick with the CLI interface of `db:migrate` and friends. So this change introduces a simple runner that someone could send a as message in the AWS Console using the following format.

```json
{
  "lamby": {
    "runner": "pwd"
  }
}
```

<img width="1166" alt="Screen Shot 2021-04-21 at 11 17 49 PM" src="https://user-images.githubusercontent.com/2381/115650798-f53d7700-a2f7-11eb-9d6a-520aebd19245.png">

Since `app.rb` is in the root of the project at `/var/task` you can put anything you need in the runner string. For example, a migration would be something like this.

```json
{
  "lamby": {
    "runner": "./bin/rails db:migrate"
  }
}
```

By supporting this interface we can not care what the task is or supporting different migrate semantics. It just becomes normal Rails commands. For example:

```json
{
  "lamby": {
    "runner": "./bin/rails db:migrate:down VERSION=20100905201547"
  }
}
```