### PR TITLE
Support EventBridge Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v2.7.0
+
+#### Added
+
+- Support EventBridge events in handler with default proc to log.
+
 ## v2.6.3
 
 #### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (2.6.3)
+    lamby (2.7.0)
       rack
 
 GEM

--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -2,6 +2,7 @@ require 'lamby/logger'
 require 'rack'
 require 'base64'
 require 'lamby/version'
+require 'lamby/config'
 require 'lamby/sam_helpers'
 require 'lamby/rack'
 require 'lamby/rack_alb'
@@ -21,6 +22,10 @@ module Lamby
 
   def handler(app, event, context, options = {})
     Handler.call(app, event, context, options)
+  end
+
+  def config
+    Lamby::Config.config
   end
 
   autoload :SsmParameterStore, 'lamby/ssm_parameter_store'

--- a/lib/lamby/config.rb
+++ b/lib/lamby/config.rb
@@ -1,0 +1,47 @@
+module Lamby
+  module Config
+
+    def configure
+      yield(config)
+      config
+    end
+
+    def reconfigure
+      config.reconfigure { |c| yield(c) if block_given? }
+    end
+
+    def config
+      @config ||= Configuration.new
+    end
+
+    extend self
+
+  end
+
+  class Configuration
+
+    def initialize
+      initialize_defaults
+    end
+
+    def reconfigure
+      instance_variables.each { |var| instance_variable_set var, nil }
+      initialize_defaults
+      yield(self) if block_given?
+      self
+    end
+
+    def initialize_defaults
+      @event_bridge_handler = lambda { |event, context| puts(event) }
+    end
+
+    def event_bridge_handler
+      @event_bridge_handler
+    end
+
+    def event_bridge_handler=(func)
+      @event_bridge_handler = func
+    end
+
+  end
+end

--- a/lib/lamby/railtie.rb
+++ b/lib/lamby/railtie.rb
@@ -1,8 +1,6 @@
 module Lamby
   class Railtie < ::Rails::Railtie
 
-    config.lamby = ActiveSupport::OrderedOptions.new
-
     rake_tasks do
       load 'lamby/tasks.rake'
       load 'lamby/templates.rake'

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '2.6.3'
+  VERSION = '2.7.0'
 end

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -275,6 +275,36 @@ class HandlerTest < LambySpec
 
   end
 
+  describe 'event_bridge' do
+
+    let(:event) do
+      {
+        "version" => "0",
+        "id"=>"0874bcac-1dac-2393-637f-201025f217b0",
+        "detail-type"=>"orderCreated",
+        "source"=>"com.myorg.stores",
+        "account"=>"123456789012",
+        "time"=>"2021-04-29T13:51:41Z",
+        "region"=>"us-east-1",
+        "resources"=>[],
+        "detail"=>{"id" => "123"}
+      }
+    end
+
+    it 'has a configurable proc' do
+      expect(Lamby.config.event_bridge_handler).must_be_instance_of Proc
+      Lamby.config.event_bridge_handler = lambda { |e,c| "#{e}#{c}" }
+      r = Lamby.config.event_bridge_handler.call(1,2)
+      expect(r).must_equal '12'
+    end
+
+    it 'basic event puts to log' do
+      out = capture(:stdout) { @result = Lamby.handler app, event, context }
+      expect(out).must_match %r{0874bcac-1dac-2393-637f-201025f217b0}
+    end
+
+  end
+
   private
 
   def session_cookie(result)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ class LambySpec < Minitest::Spec
           TestHelpers::StreamHelpers
 
   before do
+    Lamby.config.reconfigure
     delete_dummy_files
   end
 


### PR DESCRIPTION
Eventually we want to move to this interface all the time in `app.rb`. Our goal is to reflect on the incoming event and do everything right as needed.

```ruby
def handler(event:, context:)
  Lamby.handler $app, event, context
end
```

We are mature enough to know what HTTP events look like and can instantiate the proper Rack adapter as needed. This means we can also move away from code like this in the Lambdakiq gem.

```ruby
def handler(event:, context:)
  if Lambdakiq.jobs?(event)
    Lambdakiq.handler(event)
  else
    Lamby.handler $app, event, context, rack: :http
  end
end
```

When it comes to EventBridge, we can not assume the details in the message knows now to instantiate model objects or invoke tasks. As such, we simply add a default proc that applications can customize. For example in `application.rb`:

```ruby
Lamby.config.event_bridge_handler = lambda do |event, context|
   # ...
end
```

You can also set this configuration to `Lamby.config.event_bridge_handler` to false to disable this feature all together.

