### PR TITLE
Perform closing hooks on request

### DIFF
--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -50,6 +50,8 @@ module Lamby
       set_cookies if rack?
       @called = true
       self
+    ensure
+      @body.close if @body.respond_to? :close
     end
 
     def base64_encodeable?(hdrs = @headers)


### PR DESCRIPTION
### Description
Solves https://github.com/customink/lamby/issues/84.

Handlers for [Webrick](https://github.com/rack/rack/blob/master/lib/rack/handler/webrick.rb#L123) and [cgi](https://github.com/rack/rack/blob/master/lib/rack/handler/cgi.rb#L35) all perform a `.close` as part of their lifecycle. A key function in the close hook is [`clear_query_cache`](https://github.com/rails/rails/blob/v6.1.3.2/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L73).

We need to do the same.

### Notes

Without this, one specific problem is ActiveRecord query_cache does not get cleared between requests easily causing stale data to be served back to clients.