### PR TITLE
Automatically handle `Lambdakiq.jobs?(event)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v2.8.1
+
+#### Added
+
+- Automatically handle `Lambdakiq.jobs?(event)`.
+
 ## v2.8.0
 
 #### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (2.8.0)
+    lamby (2.8.1)
       rack
 
 GEM

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -87,6 +87,8 @@ module Lamby
         Debug.call @event, @context, rack.env
       elsif rack?
         @app.call rack.env
+      elsif lambdakiq?
+        Lambdakiq.handler(@event)
       elsif event_bridge?
         Lamby.config.event_bridge_handler.call @event, @context
         [200, {}, StringIO.new('')]
@@ -107,6 +109,10 @@ module Lamby
     def event_bridge?
       Lamby.config.event_bridge_handler &&
         @event.key?('source') && @event.key?('detail') && @event.key?('detail-type')
+    end
+
+    def lambdakiq?
+      defined?(::Lambdakiq) && ::Lambdakiq.job?(@event)
     end
   end
 end

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '2.8.0'
+  VERSION = '2.8.1'
 end


### PR DESCRIPTION
We want to do as much auto-detecting of what to do with an event as we logically should. I've dealt first hand with the craziness of handler wrappers for different vendors and conditionals. For as much as possible, this should be our handler interface.

```ruby
def handler(event:, context:)
  Lamby.handler $app, event, context
end
```

Once merged I will update the guides here too. https://github.com/customink/lambdakiq#bundle--config