### PR TITLE
Dynamic Hanlders with Automatic Rack Detection. Fixes #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Lamby [![Actions Status](https://github.com/customink/lamby/workflows/CI/CD/badge.svg)](https://github.com/customink/lamby/actions)
 
 <h2>Simple Rails &amp; AWS Lambda Integration</h2>
@@ -11,7 +10,7 @@ The goal of this project is to provide minimal code to allow your Rails applicat
 
 ```ruby
 def handler(event:, context:)
-  Lamby.handler $app, event, context, rack: :http
+  Lamby.handler $app, event, context
 end
 ```
 
@@ -19,11 +18,9 @@ end
 
 https://lamby.custominktech.com/docs/quick_start
 
-
 ## Full Documentation
 
 https://lamby.custominktech.com/docs/installing_aws_sam
-
 
 ## Contributing
 
@@ -36,7 +33,6 @@ $ ./bin/test
 ```
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/customink/lamby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-
 
 ## Code of Conduct
 

--- a/bin/_test
+++ b/bin/_test
@@ -4,4 +4,5 @@ set -e
 export RAILS_ENV="test"
 
 bundle exec rake test
-RACK_DEFLATE_ENABLED=1 bundle exec rake test_deflate
+LAMBY_TEST_DYNAMIC_HANDLER=1 bundle exec rake test
+LAMBY_RACK_DEFLATE_ENABLED=1 bundle exec rake test_deflate

--- a/lib/lamby/rack.rb
+++ b/lib/lamby/rack.rb
@@ -7,6 +7,22 @@ module Lamby
     LAMBDA_CONTEXT = 'lambda.context'.freeze
     HTTP_X_REQUESTID = 'HTTP_X_REQUEST_ID'.freeze
     HTTP_COOKIE = 'HTTP_COOKIE'.freeze
+    
+    class << self
+
+      def lookup(type, event)
+        types[type] || types.values.detect { |t| t.handle?(event) }
+      end
+
+      # Order is important. REST is hardest to isolated with handle? method.
+      def types
+        { alb:  RackAlb,
+          http: RackHttp,
+          rest: RackRest,
+          api:  RackRest }
+      end
+
+    end
 
     attr_reader :event, :context
 

--- a/lib/lamby/rack_alb.rb
+++ b/lib/lamby/rack_alb.rb
@@ -1,6 +1,15 @@
 module Lamby
   class RackAlb < Lamby::Rack
 
+    class << self
+
+      def handle?(event)
+        event.key?('httpMethod') && 
+          event.dig('requestContext', 'elb')
+      end
+
+    end
+
     def alb?
       true
     end

--- a/lib/lamby/rack_http.rb
+++ b/lib/lamby/rack_http.rb
@@ -1,6 +1,16 @@
 module Lamby
   class RackHttp < Lamby::Rack
 
+    class << self
+
+      def handle?(event)
+        event.key?('version') && 
+          ( event.dig('requestContext', 'http') || 
+            event.dig('requestContext', 'httpMethod') )
+      end
+
+    end
+
     def response(handler)
       if handler.base64_encodeable?
         { isBase64Encoded: true, body: handler.body64 }

--- a/lib/lamby/rack_rest.rb
+++ b/lib/lamby/rack_rest.rb
@@ -1,5 +1,13 @@
 module Lamby
   class RackRest < Lamby::Rack
+    
+    class << self
+
+      def handle?(event)
+        event.key?('httpMethod')
+      end
+
+    end
 
     def response(handler)
       if handler.base64_encodeable?

--- a/test/dummy_app/init.rb
+++ b/test/dummy_app/init.rb
@@ -40,7 +40,7 @@ module Dummy
     config.dependency_loading = true
     config.preload_frameworks = true
     config.eager_load = true
-    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater, sync: false if ENV['RACK_DEFLATE_ENABLED']
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater, sync: false if ENV['LAMBY_RACK_DEFLATE_ENABLED']
   end
 end
 


### PR DESCRIPTION
Described more in #90, we want to automatically handle all Rack options along with other events like EventBridge, Lambdakiq (see #91), Etc. vis this unified interface:

```ruby
def handler(event:, context:)
  Lamby.handler $app, event, context
end
```

To do this I have created a simple `Rack.lookup` that allows the manual rack type to still take priority but when missing each Rack subclass implements a `handle?(event)` class method. We check REST API last since that is not really distinguishable from the rest of the Rack types.