### PR TITLE
Simple Task Runner for Migrations Et Al.

### DIFF
--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -9,6 +9,7 @@ require 'lamby/rack_alb'
 require 'lamby/rack_rest'
 require 'lamby/rack_http'
 require 'lamby/debug'
+require 'lamby/runner'
 require 'lamby/handler'
 
 if defined?(Rails)

--- a/lib/lamby/config.rb
+++ b/lib/lamby/config.rb
@@ -43,5 +43,9 @@ module Lamby
       @event_bridge_handler = func
     end
 
+    def runner_patterns
+      Runner::PATTERNS
+    end
+
   end
 end

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -72,7 +72,7 @@ module Lamby
       @rack = begin
         type = rack_option
         klass = Lamby::Rack.lookup type, @event
-        klass ? klass.new(@event, @context) : false
+        (klass && klass.handle?(@event)) ? klass.new(@event, @context) : false
       end
     end
 
@@ -90,6 +90,8 @@ module Lamby
         Debug.call @event, @context, rack.env
       elsif rack?
         @app.call rack.env
+      elsif runner?
+        Runner.call(@event)
       elsif lambdakiq?
         Lambdakiq.handler(@event)
       elsif event_bridge?
@@ -116,6 +118,10 @@ module Lamby
 
     def lambdakiq?
       defined?(::Lambdakiq) && ::Lambdakiq.job?(@event)
+    end
+
+    def runner?
+      Runner.handle?(@event)
     end
   end
 end

--- a/lib/lamby/runner.rb
+++ b/lib/lamby/runner.rb
@@ -1,0 +1,58 @@
+require 'open3'
+
+module Lamby
+  class Runner
+    class Error < StandardError ; end
+    class UnknownCommandPattern < Error ; end
+
+    PATTERNS = [
+      %r{\A\./bin/(rails|rake) db:migrate.*}
+    ]
+
+    class << self
+
+      def handle?(event)
+        event.dig 'lamby', 'runner'
+      end
+
+      def call(event)
+        new(event).call
+      end
+
+    end
+
+    def initialize(event)
+      @event = event
+    end
+
+    def call
+      validate!
+      status = Open3.popen3(command, chdir: chdir) do |_stdin, stdout, stderr, thread|
+        puts stdout.read
+        puts stderr.read
+        thread.value.exitstatus
+      end
+      [status, {}, StringIO.new('')]
+    end
+
+    def command
+      @event.dig 'lamby', 'runner'
+    end
+
+    private
+
+    def chdir
+      defined?(::Rails) ? ::Rails.root : Dir.pwd
+    end
+
+    def validate!
+      return if pattern?
+      raise UnknownCommandPattern.new(command)
+    end
+
+    def pattern?
+      PATTERNS.any? { |p| p === command }
+    end
+
+  end
+end


### PR DESCRIPTION
During #80 we outlined a need for DB migration and/or task runners. The goal of that work would be to support sending your function a secure message via IAM Invoke or another AWS Event in the form of.

```json
{
  "lamby": {
    "runner": "./bin/rails db:migrate"
  }
}
```

Based on that PR's feedback we are limiting the runner's ability on which tasks it can run. The default will allow commands that match either `./bin/rake db:migrate ...` or `./bin/rails db:migrate ...`. There is an interface to either clear the pattern array (removing the feature) or push new patterns in the form of expressions or string literals. 