### PR TITLE
Lamdakiq function name fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 gem 'rails'
+
+group :test do
+  gem 'lambdakiq', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
+    aws-sdk-sqs (1.38.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-ssm (1.108.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
@@ -88,6 +91,11 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
+    lambdakiq (1.0.1)
+      activejob
+      aws-sdk-sqs
+      concurrent-ruby
+      railties
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -160,6 +168,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-ssm
   bundler
+  lambdakiq
   lamby!
   minitest
   minitest-focus

--- a/lib/lamby/handler.rb
+++ b/lib/lamby/handler.rb
@@ -117,7 +117,7 @@ module Lamby
     end
 
     def lambdakiq?
-      defined?(::Lambdakiq) && ::Lambdakiq.job?(@event)
+      defined?(::Lambdakiq) && ::Lambdakiq.jobs?(@event)
     end
 
     def runner?

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -303,6 +303,16 @@ class HandlerTest < LambySpec
       expect(out).must_match %r{0874bcac-1dac-2393-637f-201025f217b0}
     end
 
+    it 'basic event with Lambdakiq' do
+      require 'lambdakiq'
+
+      out = capture(:stdout) { @result = Lamby.handler app, event, context }
+      expect(out).must_match %r{0874bcac-1dac-2393-637f-201025f217b0}
+
+      # Unload the best we can
+      Object.send(:remove_const, :Lambdakiq)
+      ActiveJob::QueueAdapters.send(:remove_const, 'LambdakiqAdapter')
+    end
   end
 
   describe 'runner' do


### PR DESCRIPTION
### Description

Should be [`.jobs?`](https://github.com/customink/lambdakiq/blob/main/lib/lambdakiq.rb#L27) intead of `job?`

##### Updated Dependencies
 - None

### Notes

Added a spec that maintains the loose coupling to `Lambdakiq`, and duplicated a test that threw an error before. 

Happy to modify the spec as needed.