### PR TITLE
fix(ruby-27): Ruby 2.7 Warnings | Logger

### DIFF
--- a/lib/lamby/logger.rb
+++ b/lib/lamby/logger.rb
@@ -7,9 +7,9 @@ unless ENV['LAMBY_TEST']
   module Lamby
     module Logger
 
-      def initialize(*args)
+      def initialize(*args, **kwargs)
         args[0] = STDOUT
-        super(*args)
+        super(*args, **kwargs)
       end
 
     end


### PR DESCRIPTION
### Description

Lamby overrides the default implementation of `Logger` in the
standard library and provides a constructor to redirect all
log output to STDOUT.

When run in Ruby 2.7, the constructor override causes the
interpreter to emit the following warning:

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

### Changes

A simple fix for this warning is to proxy the keyword arguments
in the override to the original defnintion using the double-splat
(`**`) operator.

##### Updated Dependencies
 - None

### Ticket

* resolves https://github.com/customink/lamby/issues/104
