### PR TITLE
Add New Relic Request Queue Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v3.1.0
+
+#### Added
+
+- Add X-Request-Start header for New Relic with API Gateway.
+
 ## v3.0.3
 
 #### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-ruby2.7
+FROM public.ecr.aws/sam/build-ruby2.7:1.26.0
 
 # Asset Pipeline
 RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (3.0.3)
+    lamby (3.1.0)
       rack
 
 GEM

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -2,5 +2,4 @@
 set -e
 
 echo '== Building containers =='
-docker pull lambci/lambda:build-ruby2.7
 docker-compose build

--- a/lib/lamby/rack.rb
+++ b/lib/lamby/rack.rb
@@ -6,6 +6,7 @@ module Lamby
     LAMBDA_EVENT = 'lambda.event'.freeze
     LAMBDA_CONTEXT = 'lambda.context'.freeze
     HTTP_X_REQUESTID = 'HTTP_X_REQUEST_ID'.freeze
+    HTTP_X_REQUEST_START = 'HTTP_X_REQUEST_START'.freeze
     HTTP_COOKIE = 'HTTP_COOKIE'.freeze
     
     class << self
@@ -54,6 +55,7 @@ module Lamby
         "HTTP_#{key.to_s.upcase.tr '-', '_'}"
       end.tap do |hdrs|
         hdrs[HTTP_X_REQUESTID] = request_id
+        hdrs[HTTP_X_REQUEST_START] = request_start if request_start
       end
     end
 
@@ -107,6 +109,11 @@ module Lamby
 
     def request_id
       context.aws_request_id
+    end
+
+    def request_start
+      event.dig('requestContext', 'timeEpoch') || 
+        event.dig('requestContext', 'requestTimeEpoch')
     end
 
   end

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '3.0.3'
+  VERSION = '3.1.0'
 end


### PR DESCRIPTION
My guess here is this is the right data point available to us. Here is the documenation from a New Relic perspective (https://docs.newrelic.com/docs/apm/applications-menu/features/configure-request-queue-reporting/) and here are the docs on request time epoch from API Gateway (https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html). My hope is that this is the time the requet starts and is prior to cold start or init phase.

NOTE: There is no data for this time epoch in an ALB only integration.
