### PR TITLE
New Lamby.config.handled_proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v4.0.1
+
+### Added
+
+- New `Lamby.config.handled_proc` called with ensure via `Lamby.cmd`
+
 ## v4.0.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (4.0.0)
+    lamby (4.0.1)
       rack
 
 GEM

--- a/lib/lamby.rb
+++ b/lib/lamby.rb
@@ -22,6 +22,8 @@ module Lamby
 
   def cmd(event:, context:)
     handler(config.rack_app, event, context)
+  ensure
+    config.handled_proc.call(event, context)
   end
 
   def handler(app, event, context, options = {})

--- a/lib/lamby/config.rb
+++ b/lib/lamby/config.rb
@@ -56,5 +56,13 @@ module Lamby
       Runner::PATTERNS
     end
 
+    def handled_proc
+      @handled_proc ||= Proc.new { |_event, _context| }
+    end
+
+    def handled_proc=(proc)
+      @handled_proc = proc
+    end
+
   end
 end

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end


### PR DESCRIPTION
With the new `Lamby.cmd` docker CMD interface, we want to avoid people having to build their own handlers. The one thing we were missing is a handled proc to configure for use cases like this in LambdaPunch. https://github.com/customink/lambda_punch#-usage