### PR TITLE
Crypteia-Friendly Open3 Runner & Prep v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v4.0.2
+
+### Fixed
+
+- Runner's Open3 uses crypteia friendly env.
+
 ## v4.0.1
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lamby (4.0.1)
+    lamby (4.0.2)
       rack
 
 GEM

--- a/lib/lamby/runner.rb
+++ b/lib/lamby/runner.rb
@@ -28,7 +28,7 @@ module Lamby
 
     def call
       validate!
-      status = Open3.popen3(command, chdir: chdir) do |_stdin, stdout, stderr, thread|
+      status = Open3.popen3(env, command, chdir: chdir) do |_stdin, stdout, stderr, thread|
         @body << stdout.read
         @body << stderr.read
         puts @body
@@ -54,6 +54,10 @@ module Lamby
 
     def pattern?
       PATTERNS.any? { |p| p === command }
+    end
+
+    def env
+      Hash[ENV.to_hash.map { |k,v| [k, ENV[k]] }]
     end
 
   end

--- a/lib/lamby/version.rb
+++ b/lib/lamby/version.rb
@@ -1,3 +1,3 @@
 module Lamby
-  VERSION = '4.0.1'
+  VERSION = '4.0.2'
 end


### PR DESCRIPTION
As noted in Crypteia's issue [1] it does not support bulk environments that work around `getenv(3)`. One drawback of that is our usage of Open3 for the runner work introduced here [2]

1. https://github.com/customink/crypteia/issues/15
2. https://github.com/customink/lamby/pull/93

This pull request works around the Crypteia bulk issue by being explicit with an env object using the `Open3#popen3` interface which takes this as a first argument. https://docs.ruby-lang.org/en/2.0.0/Open3.html#method-i-popen3 When doing so, we simply create a new one that ensures `getenv(3)` is at play. I tested this in a control way in a Crypteia Codespace.


<img width="1280" alt="Screen Shot 2023-02-08 at 5 25 03 PM" src="https://user-images.githubusercontent.com/2381/217667497-cb02342f-25cf-4ccd-a4ad-c633b1935c10.png">
