### PR TITLE
Fix release workflow Ruby version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: ruby
+          ruby-version: .ruby-version
 
       # Release
       - uses: rubygems/release-gem@v1


### PR DESCRIPTION
Use `.ruby-version` instead of `ruby` in the release workflow so it matches the pinned version in `Gemfile.lock` and avoids a bundler deployment mode conflict.